### PR TITLE
Stop using scaffold command to create apiblueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [WIP] apiblueprint-rails
+# apiblueprint-rails
 
-apiblueprint-rails creates [API Blueprint](https://apiblueprint.org/) boilerplate when generating scaffold by rails.
+apiblueprint-rails creates [API Blueprint](https://apiblueprint.org/) boilerplate when calling `rails g apiblueprint`.
 
 ## Installation
 
@@ -18,11 +18,11 @@ $ bundle
 
 ## Usage
 
-After installing apiblueprint-rails to your rails application, generating scaffold just triggers apiblueprint generator.
+After installing apiblueprint-rails to your rails application, use apiblueprint keyword to generate scaffold.
 For example,
 
 ```bash
-$ rails g scaffold User name age:integer admin:boolean
+$ rails g apiblueprint User name age:integer admin:boolean
 ```
 
 creates `doc/users.apib` file.
@@ -30,10 +30,10 @@ creates `doc/users.apib` file.
 You can change `doc` directory by passing `--apidoc-dir=<directory>` flag to the option.
 
 
-If you want to generate apiblueprint only, you can use `rails generate apiblueprint` command.
+If you want to generate apiblueprint only, you can use `rails generate apiblueprint --generate=none` command.
 
 ```bash
-$ rails g apiblueprint User name age:integer admin:boolean
+$ rails g apiblueprint --generate=none User name age:integer admin:boolean
 ```
 
 generates just the same apib output above.

--- a/lib/apiblueprint/rails.rb
+++ b/lib/apiblueprint/rails.rb
@@ -1,18 +1,6 @@
 require "apiblueprint/rails/version"
-require "rails/generators"
-require "rails/generators/rails/scaffold/scaffold_generator"
 
 module Apiblueprint
   module Rails
-    class Railtie < ::Rails::Railtie
-      config.after_initialize do
-        module ::Rails::Generators
-          class ScaffoldGenerator < ResourceGenerator
-            class_option :apidoc, desc: "Api document format", default: :apiblueprint
-            hook_for :apidoc, required: true
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/generators/rails/apiblueprint/apiblueprint_generator.rb
+++ b/lib/generators/rails/apiblueprint/apiblueprint_generator.rb
@@ -12,7 +12,7 @@ class Rails::ApiblueprintGenerator < Rails::Generators::NamedBase
   )
 
   class_option "apidoc-dir", type: :string, default: "doc", desc: "Change doc directory by passing"
-  class_option "generate-type", type: :string, default: "scaffold", desc: "Change generate type (Default:scaffold, Other: none, controller, model...)"
+  class_option "generate", type: :string, default: "scaffold", desc: "Change generate type (Default:scaffold, Other: none, controller, model...)"
 
   def set_attribute
     @attrs = Array.new()
@@ -38,8 +38,8 @@ class Rails::ApiblueprintGenerator < Rails::Generators::NamedBase
 
   def create_apib_file
     template "apiblueprint.erb", "#{options["apidoc-dir"]}/#{file_name}.apib"
-    if options["generate-type"] != "none" then
-      invoke(options["generate-type"], [file_name, @args])
+    if options["generate"] != "none" then
+      invoke(options["generate"], [file_name, @args])
     end
   end
 end


### PR DESCRIPTION
# WHY
- Custom scaffold command has bugs.
# WHAT
- Stop using scaffold command to create apiblueprint.
