### PR TITLE
Prepare for gem release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/apiblueprint-rails.gemspec
+++ b/apiblueprint-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "railties", ">= 3.0.0"
+  spec.add_runtime_dependency "railties", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Remove warning when `gem build apiblueprint-rails.gemspec`, and add .gitignore not to track `apiblueprint-rails-0.1.0.gem` etc
